### PR TITLE
removed a literal caomparison pitfall from the code

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -972,7 +972,7 @@ def follow_image_aspect_ratio(depth, image):
     return depth
 
 def depth_resize(depth, origin_size, image_size):
-    if origin_size[0] is not 0:
+    if origin_size[0] != 0:
         max_depth = depth.max()
         depth = depth / max_depth
         depth = resize(depth, origin_size, order=1, mode='edge')


### PR DESCRIPTION
**The problem**
In Python when comparing to non-singleton values, it advised to use the operator '==' instead of 'is'.
By doing otherwise, we may fall into the a code pitfall which can be detected by pylint under the identification of R0123 literal-comparison https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/R0123.html

**The solution**
Refactored the comparison on literals