### PR TITLE
fixed load bug from pyaml

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,12 @@ from bilateral_filtering import sparse_bilateral_filtering
 parser = argparse.ArgumentParser()
 parser.add_argument('--config', type=str, default='argument.yml',help='Configure of post processing')
 args = parser.parse_args()
-config = yaml.load(open(args.config, 'r'))
+
+try:
+  config = yaml.load(open(args.config, 'r'))
+except Exception:
+  config = yaml.safe_load(open(args.config, 'r'))
+
 if config['offscreen_rendering'] is True:
     vispy.use(app='egl')
 os.makedirs(config['mesh_folder'], exist_ok=True)


### PR DESCRIPTION
newer versions of pyaml require a Loader parameter on load.  This patch tries to load it that old way and then falls back to .safe_load()