### PR TITLE
fix(sec): upgrade networkx to 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ opencv-python==4.2.0.32
 vispy==0.6.4
 moviepy==1.0.2
 transforms3d==0.3.1
-networkx==2.3
+networkx==2.6
 cynetworkx
 scikit-image


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in networkx 2.3
- [MPS-2022-15000](https://www.oscs1024.com/hd/MPS-2022-15000)


### What did I do？
Upgrade networkx from 2.3 to 2.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS